### PR TITLE
argparse command line interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt purge -y \
     git
 WORKDIR /GeoMetrics
 CMD echo "Please run GeoMetrics with an AOI configuration"\
-    echo "docker run --rm -v /home/ubuntu/annoteGeoExamples:/data jhuapl/geometrics python3 run_geometrics.py<aoi config>"
+    echo "docker run --rm -v /home/ubuntu/annoteGeoExamples:/data jhuapl/geometrics python3 run_geometrics.py -c <aoi config>"

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -2,89 +2,111 @@
 # Run all CORE3D metrics and report results.
 #
 
+import os
 import sys
 import configparser
 import gdal
 import numpy as np
 import geometrics as geo
+import argparse
 
-# Get configuration file name from CLI and parse it.	
-if len(sys.argv) < 2:
-    print("Example use: runMetrics aoi-d1.config")
-    sys.exit()
-configFilename = sys.argv[1]
-print("")
-print("Reading configuration from " + configFilename)
-print("")
-config = configparser.ConfigParser()
-if len(config.read(configFilename)) == 0:
-    print("Error: Unable to read selected .config file")
-    sys.exit()
 
-# Get test model information from configuration file.
-testDSMFilename = config['INPUT.TEST']['DSMFilename']
-testDTMFilename = config['INPUT.TEST']['DTMFilename']
-testCLSFilename = config['INPUT.TEST']['CLSFilename']
-testMTLFilename = config['INPUT.TEST']['MTLFilename']
-TEST_CLS_VALUE = config.getint('INPUT.TEST', 'CLSMatchValue')
 
-# Get reference model information from configuration file.
-refDSMFilename = config['INPUT.REF']['DSMFilename']
-refDTMFilename = config['INPUT.REF']['DTMFilename']
-refCLSFilename = config['INPUT.REF']['CLSFilename']
-refNDXFilename = config['INPUT.REF']['NDXFilename']
-refMTLFilename = config['INPUT.REF']['MTLFilename']
-REF_CLS_VALUE = config.getint('INPUT.REF', 'CLSMatchValue')
+def run_geometrics(configfile):
 
-# Get material label names and list of material labels to ignore in evaluation.
-materialNames = config['MATERIALS.REF']['MaterialNames'].split(',')
-materialIndicesToIgnore = list(map(int, config['MATERIALS.REF']['MaterialIndicesToIgnore'].split(',')))
+    # check inputs
+    if not os.path.isfile(configfile):
+        raise IOError("Configuration file does not exist")
 
-# Register test model to ground truth reference model.
-align3d_path = config['REGEXEPATH']['Align3DPath']
-xyzOffset = geo.align3d(refDSMFilename, testDSMFilename, ExecPath=align3d_path)
+    # parse configuration file
+    print("")
+    print("Reading configuration from " + configfile)
+    print("")
+    config = configparser.ConfigParser()
+    if len(config.read(configfile)) == 0:
+        raise IOError("Unable to read selected .config file")
 
-# Read reference model files.
-print("")
-print("Reading reference model files...")
-refMask, tform = geo.imageLoad(refCLSFilename)
-refDSM = geo.imageWarp(refDSMFilename, refCLSFilename)
-refDTM = geo.imageWarp(refDTMFilename, refCLSFilename)
+    # Get test model information from configuration file.
+    testDSMFilename = config['INPUT.TEST']['DSMFilename']
+    testDTMFilename = config['INPUT.TEST']['DTMFilename']
+    testCLSFilename = config['INPUT.TEST']['CLSFilename']
+    testMTLFilename = config['INPUT.TEST']['MTLFilename']
+    TEST_CLS_VALUE = config.getint('INPUT.TEST', 'CLSMatchValue')
 
-# Read test model files and apply XYZ offsets.
-print("Reading test model files...")
-print("")
-testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
-testMask = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdal.gdalconst.GRA_NearestNeighbour)
-testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset)
-testDSM = testDSM + xyzOffset[2]
-testDTM = testDTM + xyzOffset[2]
+    # Get reference model information from configuration file.
+    refDSMFilename = config['INPUT.REF']['DSMFilename']
+    refDTMFilename = config['INPUT.REF']['DTMFilename']
+    refCLSFilename = config['INPUT.REF']['CLSFilename']
+    refNDXFilename = config['INPUT.REF']['NDXFilename']
+    refMTLFilename = config['INPUT.REF']['MTLFilename']
+    REF_CLS_VALUE = config.getint('INPUT.REF', 'CLSMatchValue')
 
-# Create mask for ignoring points labeled NoData in reference files.
-refDSM_NoDataValue = geo.getNoDataValue(refDSMFilename)
-refDTM_NoDataValue = geo.getNoDataValue(refDTMFilename)
-refCLS_NoDataValue = geo.getNoDataValue(refCLSFilename)
-ignoreMask = np.zeros_like(refMask, np.bool)
+    # Get material label names and list of material labels to ignore in evaluation.
+    materialNames = config['MATERIALS.REF']['MaterialNames'].split(',')
+    materialIndicesToIgnore = list(map(int, config['MATERIALS.REF']['MaterialIndicesToIgnore'].split(',')))
 
-if refDSM_NoDataValue is not None:
-    ignoreMask[refDSM == refDSM_NoDataValue] = True
-if refDTM_NoDataValue is not None:
-    ignoreMask[refDTM == refDTM_NoDataValue] = True
-if refCLS_NoDataValue is not None:
-    ignoreMask[refMask == refCLS_NoDataValue] = True
+    # Register test model to ground truth reference model.
+    align3d_path = config['REGEXEPATH']['Align3DPath']
+    xyzOffset = geo.align3d(refDSMFilename, testDSMFilename, ExecPath=align3d_path)
 
-# If quantizing to voxels, then match vertical spacing to horizontal spacing.
-QUANTIZE = config.getboolean('OPTIONS', 'QuantizeHeight')
-if QUANTIZE:
-    unitHgt = (np.abs(tform[1]) + abs(tform[5])) / 2
-    refDSM = np.round(refDSM / unitHgt) * unitHgt
-    refDTM = np.round(refDTM / unitHgt) * unitHgt
-    testDSM = np.round(testDSM / unitHgt) * unitHgt
-    testDTM = np.round(testDTM / unitHgt) * unitHgt
+    # Read reference model files.
+    print("")
+    print("Reading reference model files...")
+    refMask, tform = geo.imageLoad(refCLSFilename)
+    refDSM = geo.imageWarp(refDSMFilename, refCLSFilename)
+    refDTM = geo.imageWarp(refDTMFilename, refCLSFilename)
 
-# Run the threshold geometry metrics and report results.
-geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
-                                   tform, xyzOffset, testDSMFilename, ignoreMask)
+    # Read test model files and apply XYZ offsets.
+    print("Reading test model files...")
+    print("")
+    testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
+    testMask = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdal.gdalconst.GRA_NearestNeighbour)
+    testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset)
+    testDSM = testDSM + xyzOffset[2]
+    testDTM = testDTM + xyzOffset[2]
 
-# Run the threshold material metrics and report results.
-geo.run_material_metrics(refNDXFilename, refMTLFilename, testMTLFilename, materialNames, materialIndicesToIgnore)
+    # Create mask for ignoring points labeled NoData in reference files.
+    refDSM_NoDataValue = geo.getNoDataValue(refDSMFilename)
+    refDTM_NoDataValue = geo.getNoDataValue(refDTMFilename)
+    refCLS_NoDataValue = geo.getNoDataValue(refCLSFilename)
+    ignoreMask = np.zeros_like(refMask, np.bool)
+
+    if refDSM_NoDataValue is not None:
+        ignoreMask[refDSM == refDSM_NoDataValue] = True
+    if refDTM_NoDataValue is not None:
+        ignoreMask[refDTM == refDTM_NoDataValue] = True
+    if refCLS_NoDataValue is not None:
+        ignoreMask[refMask == refCLS_NoDataValue] = True
+
+    # If quantizing to voxels, then match vertical spacing to horizontal spacing.
+    QUANTIZE = config.getboolean('OPTIONS', 'QuantizeHeight')
+    if QUANTIZE:
+        unitHgt = (np.abs(tform[1]) + abs(tform[5])) / 2
+        refDSM = np.round(refDSM / unitHgt) * unitHgt
+        refDTM = np.round(refDTM / unitHgt) * unitHgt
+        testDSM = np.round(testDSM / unitHgt) * unitHgt
+        testDTM = np.round(testDTM / unitHgt) * unitHgt
+
+    # Run the threshold geometry metrics and report results.
+    geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
+                                       tform, xyzOffset, testDSMFilename, ignoreMask)
+
+    # Run the threshold material metrics and report results.
+    geo.run_material_metrics(refNDXFilename, refMTLFilename, testMTLFilename, materialNames, materialIndicesToIgnore)
+
+
+# command line function
+def main():
+
+  # parse inputs
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-c', '--config', dest='config', 
+      help='Configuration file', required=True)
+  
+  args = parser.parse_args()
+  run_geometrics(configfile=args.config)
+
+
+if __name__ == "__main__":
+  main()
+


### PR DESCRIPTION
Add [argparse](https://docs.python.org/3/library/argparse.html) for improved command line interface.  
* Improves user understanding of command line arguments
* Allowing other python modules to directly call "run_geometrics" function

(Note this change looks large, but is mostly just an additional alignment tab).