### PR TITLE
add docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2.3"
+
+services:
+  geometrics:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: jhuapl/geometrics
+    volumes:
+      - .:/src:ro


### PR DESCRIPTION
Add [docker-compose](https://docs.docker.com/compose/) functionality.  This allows you to build the docker without entering tags:
`docker-compose build
`

and run the service, auto-mounting the current directory as a volume @ /src.
`docker-compose run --rm -v "<DATA>/data" geometrics python3 /src/run_geometrics.py /data/aoi.config`

Auto-mounting the current directory allows users to more easily run the current version of their code base within the docker (instead of master branch code cloned into /GeoMetrics within the Dockerfile).