### PR TITLE
Material

### DIFF
--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -6,7 +6,7 @@ import os
 import sys
 import shutil
 import configparser
-import gdal
+import gdal, gdalconst
 import numpy as np
 import geometrics as geo
 import argparse
@@ -71,13 +71,17 @@ def run_geometrics(configfile,outputpath=None):
     refMask, tform = geo.imageLoad(refCLSFilename)
     refDSM = geo.imageWarp(refDSMFilename, refCLSFilename)
     refDTM = geo.imageWarp(refDTMFilename, refCLSFilename)
+    refNDX = geo.imageWarp(refNDXFilename, refCLSFilename, interp_method=gdalconst.GRA_NearestNeighbour).astype(np.uint16)
+    refMTL = geo.imageWarp(refMTLFilename, refCLSFilename, interp_method=gdalconst.GRA_NearestNeighbour).astype(np.uint8)
 
     # Read test model files and apply XYZ offsets.
     print("Reading test model files...")
     print("")
     testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
-    testMask = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdal.gdalconst.GRA_NearestNeighbour)
+    testMask = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour)
     testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset)
+    testMTL = geo.imageWarp(testMTLFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour).astype(np.uint8)
+
     testDSM = testDSM + xyzOffset[2]
     testDTM = testDTM + xyzOffset[2]
 
@@ -108,7 +112,7 @@ def run_geometrics(configfile,outputpath=None):
                                        tform, xyzOffset, testDSMFilename, ignoreMask, outputpath=outputpath)
 
     # Run the threshold material metrics and report results.
-    geo.run_material_metrics(refNDXFilename, refMTLFilename, testMTLFilename, materialNames, materialIndicesToIgnore)
+    geo.run_material_metrics(refNDX, refMTL, testMTL, materialNames, materialIndicesToIgnore)
 
 
 # command line function


### PR DESCRIPTION
Bring `run_material_metrics` in line with rest of system.
* Use image load capabilities from `image.py` (delete from `threshold_material_metrics.py`) to load & transform material related imagery in `run_geometrics`
* Use "xxxMTL" instead of "xxxMAT"

Note all MTL and NDX imagery is loaded with nearest neighbor interpolation. MTL imagery is loaded as an uint8, while NDX imagery is loaded as an uint16 to accomodate the possibility of more than 255 building labels.