### PR TITLE
JSON input and output 

### DIFF
--- a/aoi-example/aoi-example.json
+++ b/aoi-example/aoi-example.json
@@ -1,0 +1,31 @@
+{
+  "INPUT.REF": {
+    "DSMFilename": "/path_to/ground_truth-DSM.tif",
+    "DTMFilename": "/path_to/ground_truth-DTM.tif",
+    "CLSFilename": "/path_to/ground_truth-CLS.tif",
+    "NDXFilename": "/path_to/ground_truth-NDX.tif",
+    "MTLFilename": "/path_to/ground_truth--MTL.tif",
+    "CLSMatchValue": 6,
+  },
+  "INPUT.TEST": {
+    "DSMFilename": "/path_to/test_model-DSM.tif",
+    "DTMFilename": "/path_to/test_model-DTM.tif",
+    "CLSFilename": "/path_to/test_model-CLS.tif",
+    "MTLFilename": "/path_to/test_model-MTL.tif",
+    "CLSMatchValue": 6
+  },
+  "OPTIONS": {
+    "QuantizeHeight": true
+  },
+  "PLOTS": {
+    "DoPlots": false
+  },
+  "REGEXEPATH": {
+    "Align3DPath": "/build"
+  },
+  "MATERIALS.REF": {
+    "MaterialIndices": [0,1,2,3,4,5,6,7,8,9,10,11],
+    "MaterialNames": ["Unclassified","Asphalt","Concrete/Stone","Glass","Tree","Non-tree vegetation","Metal","Red ceramic","Soil","Solar panel","Water","Polymer"],
+    "MaterialIndicesToIgnore": [12]
+  }
+}

--- a/geometrics/registration.py
+++ b/geometrics/registration.py
@@ -8,16 +8,15 @@ import numpy as np
 import gdal
 
 
-def align3d(reference_filename, test_filename, **keyword_parameters):
-    # Determine location of the align3d executable.
-    if 'ExecPath' in keyword_parameters:
-        print("Working Directory parameter specified: ", keyword_parameters['ExecPath'])
-        exec_path = keyword_parameters["ExecPath"]
-    else:
-        print("No working directory parameter specified, default is the current working directory")
-        exec_path = os.path.dirname(os.path.realpath(__file__))
-    exec_path = os.path.abspath(exec_path)
-    exec_filename = os.path.join(exec_path, 'align3d')
+def align3d(reference_filename, test_filename, exec_path=None):
+
+    # default location of the align3d executable.
+    if exec_path is None: exec_path = os.path.dirname(os.path.realpath(__file__))
+
+    # locate align3d executable
+    exec_filename = os.path.abspath(os.path.join(exec_path,'align3d'))
+    if not os.path.isfile(exec_filename):
+        raise IOError('"align3d" executable not found at <{}>'.format(exec_filename))
 
     # In case file names have relative paths, convert to absolute paths.
     reference_filename = os.path.abspath(reference_filename)

--- a/geometrics/registration.py
+++ b/geometrics/registration.py
@@ -49,15 +49,11 @@ def align3d(reference_filename, test_filename, **keyword_parameters):
 
 
 def readXYZoffset(filename):
-    xyz_offset = np.zeros([3, 1])
-    file_obj = open(filename, "r")
-    offset_string = file_obj.readlines()
-    cc = offset_string[1].split(' ')
-    xyz_offset[0] = cc[0]
-    xyz_offset[1] = cc[2]
-    xyz_offset[2] = cc[4]
-    file_obj.close()
-    return xyz_offset
+    with open(filename, "r") as fid:
+        offsetstr = fid.readlines()        
+    cc = offsetstr[1].split(' ')
+    xyzoffset = [float(v) for v in [cc[0],cc[2],cc[4]]]
+    return xyzoffset
 
 
 def getXYZoffsetFilename(testFilename):

--- a/geometrics/threshold_geometry_metrics.py
+++ b/geometrics/threshold_geometry_metrics.py
@@ -16,43 +16,8 @@ def calcMops(true_positives, false_negatives, false_positives):
     return s
 
 
-def printMetrics(metrics, results_file_name=None):
-    write_to_file = False
-    f = None
-    if results_file_name:
-        write_to_file = True
-        f = open(results_file_name, 'w')
-        print("Writing metric results to:  %s" % results_file_name)
-
-    def tee(message, include_in_file, file):
-        print(message)
-        if include_in_file:
-            file.writelines("%s\n" % message)
-
-    string = ("%s: %0.3f" % ('Completeness', metrics['completeness']))
-    tee(string, write_to_file, f)
-    string = ("%s: %0.3f" % ('Correctness', metrics['correctness']))
-    tee(string, write_to_file, f)
-    string = ("%s: %0.3f" % ('F-Score', metrics['fscore']))
-    tee(string, write_to_file, f)
-    string = ("%s: %0.3f" % ('Jaccard Index', metrics['jaccardIndex']))
-    tee(string, write_to_file, f)
-    string = ("%s: %0.3f" % ('Branching Factor', metrics['branchingFactor']))
-    tee(string, write_to_file, f)
-    string = ("%s: %0.3f" % ('Miss Factor', metrics['missFactor']))
-    tee(string, write_to_file, f)
-
-    if 'offset' in metrics:
-        val = metrics["offset"]
-        string = ("%s: (%0.3f, %0.3f, %0.3f)" % ("Registration Offset (m)", val[0], val[1], val[2]))
-        tee(string, write_to_file, f)
-
-    if write_to_file:
-        f.close()
-
-
 def run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
-                                   tform, xyzOffset, testDSMFilename, ignoreMask, outputpath=None):
+                                   tform, ignoreMask):
     refMask = (refMask == REF_CLS_VALUE)
     refHgt = (refDSM - refDTM)
     refObj = refHgt
@@ -117,20 +82,9 @@ def run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testD
     tolFN = false_negatives + oobFN
     tolTP = true_positives
 
-    metrics_2d = calcMops(unitCountTP, unitCountFN, unitCountFP)
-    metrics_3d = calcMops(tolTP, tolFN, tolFP)
+    metrics = {
+        '2D': calcMops(unitCountTP, unitCountFN, unitCountFP),
+        '3D': calcMops(tolTP, tolFN, tolFP),
+    }
 
-    metrics_3d['offset'] = xyzOffset
-
-    if outputpath is None:
-        outputpath = os.path.dirname(testDSMFilename)
-
-    print('')
-    print('2D Metrics:')
-    results_filename = os.path.join(outputpath,os.path.basename(testDSMFilename) + "_2d_metrics.txt")
-    printMetrics(metrics_2d, results_filename)
-
-    print('')
-    print('3D Metrics:')
-    results_filename = os.path.join(outputpath,os.path.basename(testDSMFilename) + "_3d_metrics.txt")
-    printMetrics(metrics_3d, results_filename)
+    return metrics

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -10,6 +10,7 @@ import gdal, gdalconst
 import numpy as np
 import geometrics as geo
 import argparse
+import json
 
 
 
@@ -19,20 +20,53 @@ def run_geometrics(configfile,outputpath=None):
     if not os.path.isfile(configfile):
         raise IOError("Configuration file does not exist")
 
+
     # parse configuration file
     print("")
     print("Reading configuration from " + configfile)
     print("")
-    config = configparser.ConfigParser()
-    if len(config.read(configfile)) == 0:
-        raise IOError("Unable to read selected .config file")
+
+    # JSON parsing
+    if configfile.endswith(('.json','.JSON')):
+
+        # open & read JSON file
+        with open(configfile,'r') as fid:
+            config = json.load(fid)
+
+    # CONFIG parsing
+    elif configfile.endswith(('.config','.CONFIG')):
+
+        # setup config parser
+        parser = configparser.ConfigParser()
+        parser.optionxform = str # maintain case-sensitive items
+
+        # read entire configuration file into dict
+        if len(parser.read(configfile)) == 0:
+            raise IOError("Unable to read selected .config file")
+        config = {s:dict(parser.items(s)) for s in parser.sections()}   
+
+        # special section/item parsing
+        s = 'INPUT.TEST'; i = 'CLSMatchValue'; config[s][i] = int(config[s][i])
+        s = 'INPUT.REF'; i = 'CLSMatchValue'; config[s][i] = int(config[s][i])
+        s = 'OPTIONS'; i = 'QuantizeHeight'; config[s][i] = bool(config[s][i])
+        s = 'PLOTS'; i = 'DoPlots'; config[s][i] = bool(config[s][i])
+        s = 'MATERIALS.REF'; i = 'MaterialNames'; config[s][i] = config[s][i].split(',')
+        s = 'MATERIALS.REF'; i = 'MaterialIndicesToIgnore'; config[s][i] = list(map(int, config[s][i].split(',')))
+
+    # unrecognized config file type
+    else:
+        raise IOError('Unrecognized configuration file')
+
+    # print final configuration
+    print(json.dumps(config,indent=2))
+
 
     # Get test model information from configuration file.
     testDSMFilename = config['INPUT.TEST']['DSMFilename']
     testDTMFilename = config['INPUT.TEST']['DTMFilename']
     testCLSFilename = config['INPUT.TEST']['CLSFilename']
     testMTLFilename = config['INPUT.TEST']['MTLFilename']
-    TEST_CLS_VALUE = config.getint('INPUT.TEST', 'CLSMatchValue')
+    TEST_CLS_VALUE = config['INPUT.TEST']['CLSMatchValue']
 
     # Get reference model information from configuration file.
     refDSMFilename = config['INPUT.REF']['DSMFilename']
@@ -40,11 +74,11 @@ def run_geometrics(configfile,outputpath=None):
     refCLSFilename = config['INPUT.REF']['CLSFilename']
     refNDXFilename = config['INPUT.REF']['NDXFilename']
     refMTLFilename = config['INPUT.REF']['MTLFilename']
-    REF_CLS_VALUE = config.getint('INPUT.REF', 'CLSMatchValue')
+    REF_CLS_VALUE = config['INPUT.REF']['CLSMatchValue']
 
     # Get material label names and list of material labels to ignore in evaluation.
-    materialNames = config['MATERIALS.REF']['MaterialNames'].split(',')
-    materialIndicesToIgnore = list(map(int, config['MATERIALS.REF']['MaterialIndicesToIgnore'].split(',')))
+    materialNames = config['MATERIALS.REF']['MaterialNames']
+    materialIndicesToIgnore = config['MATERIALS.REF']['MaterialIndicesToIgnore']
 
     # check output path
     if outputpath is None:
@@ -99,7 +133,7 @@ def run_geometrics(configfile,outputpath=None):
         ignoreMask[refMask == refCLS_NoDataValue] = True
 
     # If quantizing to voxels, then match vertical spacing to horizontal spacing.
-    QUANTIZE = config.getboolean('OPTIONS', 'QuantizeHeight')
+    QUANTIZE = config['OPTIONS']['QuantizeHeight']
     if QUANTIZE:
         unitHgt = (np.abs(tform[1]) + abs(tform[5])) / 2
         refDSM = np.round(refDSM / unitHgt) * unitHgt

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -22,9 +22,7 @@ def run_geometrics(configfile,outputpath=None):
 
 
     # parse configuration file
-    print("")
-    print("Reading configuration from " + configfile)
-    print("")
+    print("\nReading configuration from <{}>".format(configfile))
 
     # JSON parsing
     if configfile.endswith(('.json','.JSON')):
@@ -142,8 +140,15 @@ def run_geometrics(configfile,outputpath=None):
         testDTM = np.round(testDTM / unitHgt) * unitHgt
 
     # Run the threshold geometry metrics and report results.
-    geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
-                                       tform, xyzOffset, testDSMFilename, ignoreMask, outputpath=outputpath)
+    metrics = geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
+                                       tform, ignoreMask)
+
+    metrics['offset'] = xyzOffset
+    
+    fileout = os.path.join(outputpath,os.path.basename(testDSMFilename) + "_metrics.json")
+    with open(fileout,'w') as fid:
+        json.dump(metrics,fid,indent=2)
+    print(json.dumps(metrics,indent=2))
 
     # Run the threshold material metrics and report results.
     geo.run_material_metrics(refNDX, refMTL, testMTL, materialNames, materialIndicesToIgnore)

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -95,7 +95,7 @@ def run_geometrics(configfile,outputpath=None):
     # Register test model to ground truth reference model.
     print('\n=====REGISTRATION====='); sys.stdout.flush()
     align3d_path = config['REGEXEPATH']['Align3DPath']
-    xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy, ExecPath=align3d_path)
+    xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy, exec_path=align3d_path)
 
     # Read reference model files.
     print("")


### PR DESCRIPTION
Allow JSON configuration file in addition to the CONFIG file format.  JSON is a more flexible format, with easier reading and writing within python.  Old CONFIG files should still work.  Example JSON provided.

Also remove output writing from the threshold_geometry_metrics file, instead outputting a JSON metrics summary from the main function.  The JSON output will allow automated collation and analysis across multiple software runs.

Additional change to the registration function to conform with python standards.