### PR TITLE
ALIGN3D in PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ WORKDIR /
 RUN git clone https://github.com/pubgeo/GeoMetrics
 RUN apt purge -y \
     git
+
+# add "align3d" to path
+ENV PATH="${PATH:+${PATH}:}/build"
+
 WORKDIR /GeoMetrics
 CMD echo "Please run GeoMetrics with an AOI configuration"\
     echo "docker run --rm -v /home/ubuntu/annoteGeoExamples:/data jhuapl/geometrics python3 run_geometrics.py -c <aoi config>"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The following python3 libraries (and their dependencies) are required:
 * scipy
 * tk
 
+Users must also have installed pubgeo's [ALIGN3D](https://github.com/pubgeo/pubgeo/#align3d) software. Software must be compiled and available on $PATH. 
+
 Alternatively, you can use the provided docker [container](Dockerfile).
 
 ### core3d-metrics Usage
@@ -35,5 +37,4 @@ to toggle various software settings.
 This command would perform metric analysis on the test dataset provided by the aoi.config file. This analysis will also generate the following files (in place):
 * < test dataset >_2d_metrics.txt
 * < test dataset >_3d_metrics.txt
-
 These files contain the determined metrics for completeness, correctness, f-score, Jaccard Index, Branching Factor, and the Align3d offsets.

--- a/aoi-example/README.md
+++ b/aoi-example/README.md
@@ -46,11 +46,6 @@ This section is denoted by the \[PLOTS\] tag and is used to set options for draw
 ## SavePlots
  After this is implemented, this boolean will enable saving plots to file.
 
-# Registration Executable Path
-This section is denoted by the \[REGEXEPATH\] tag and is used to locate executable files.
-## Align3DPath
- Relative or absolute path to pubgeo's Align3d executable
-
 # Materials Reference
 This section is denoted by the \[MATERIALS.REF\] tag and is used to describe material labels
 ## MaterialIndices

--- a/aoi-example/aoi-example.config
+++ b/aoi-example/aoi-example.config
@@ -19,10 +19,6 @@ QuantizeHeight  = true
 [PLOTS]
 DoPlots         = 0
 
-[REGEXEPATH]
-# This default works for docker image
-Align3DPath = /build
-
 [MATERIALS.REF]
 MaterialIndices = 0,1,2,3,4,5,6,7,8,9,10,11
 MaterialNames = Unclassified,Asphalt,Concrete/Stone,Glass,Tree,Non-tree vegetation,Metal,Red ceramic,Soil,Solar panel,Water,Polymer

--- a/aoi-example/aoi-example.json
+++ b/aoi-example/aoi-example.json
@@ -20,9 +20,6 @@
   "PLOTS": {
     "DoPlots": false
   },
-  "REGEXEPATH": {
-    "Align3DPath": "/build"
-  },
   "MATERIALS.REF": {
     "MaterialIndices": [0,1,2,3,4,5,6,7,8,9,10,11],
     "MaterialNames": ["Unclassified","Asphalt","Concrete/Stone","Glass","Tree","Non-tree vegetation","Metal","Red ceramic","Soil","Solar panel","Water","Polymer"],

--- a/geometrics/registration.py
+++ b/geometrics/registration.py
@@ -8,22 +8,14 @@ import numpy as np
 import gdal
 
 
-def align3d(reference_filename, test_filename, exec_path=None):
-
-    # default location of the align3d executable.
-    if exec_path is None: exec_path = os.path.dirname(os.path.realpath(__file__))
-
-    # locate align3d executable
-    exec_filename = os.path.abspath(os.path.join(exec_path,'align3d'))
-    if not os.path.isfile(exec_filename):
-        raise IOError('"align3d" executable not found at <{}>'.format(exec_filename))
+def align3d(reference_filename, test_filename):
 
     # In case file names have relative paths, convert to absolute paths.
     reference_filename = os.path.abspath(reference_filename)
     test_filename = os.path.abspath(test_filename)
 
     # Run align3d.
-    command = exec_filename + " " + reference_filename + " " + test_filename + ' maxt=10.0'
+    command = "align3d " + reference_filename + " " + test_filename + ' maxt=10.0'
     print("")
     print("Registering test model to reference model to determine XYZ offset.")
     print("")

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -151,8 +151,7 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
 
     # Register test model to ground truth reference model.
     print('\n=====REGISTRATION====='); sys.stdout.flush()
-    align3d_path = config['REGEXEPATH']['Align3DPath']
-    xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy, exec_path=align3d_path)
+    xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy)
 
     # Read reference model files.
     print("")


### PR DESCRIPTION
The path to pubgeo's ALIGN3D software is a system-level configuration option that need only be defined once (not in every core3d-metrics configuration file).  Users can be reasonably expected to add ALIGN3D to their path, rather than have to specify the ALIGN3D executable location in every configuration file.  

Suggest adding ALIGN3D location `/build` to the docker `PATH`, and removing the `REGEXEPATH` configuration option.  Note this also makes the configuration generalize across deployments (e.g., the same configuration file works on a regular workstation and the docker environment).

Testing this change does require a docker build. If running without the docker, make sure to add the ALIGN3D folder to your PATH environment variable.
