### PR TITLE
Allow CLSMatchValue list

### DIFF
--- a/aoi-example/aoi-example.config
+++ b/aoi-example/aoi-example.config
@@ -4,7 +4,7 @@ DTMFilename  = /path_to/ground_truth-DTM.tif
 CLSFilename  = /path_to/ground_truth-CLS.tif
 NDXFilename  = /path_to/ground_truth-NDX.tif
 MTLFilename  = /path_to/ground_truth--MTL.tif
-CLSMatchValue  = 6
+CLSMatchValue  = 6,65
 
 [INPUT.TEST]
 DSMFilename  = /path_to/test_model-DSM.tif
@@ -17,7 +17,7 @@ CLSMatchValue  = 6
 QuantizeHeight  = true
 
 [PLOTS]
-DoPlots         = 0
+DoPlots         = false
 
 [REGEXEPATH]
 # This default works for docker image

--- a/aoi-example/aoi-example.json
+++ b/aoi-example/aoi-example.json
@@ -5,7 +5,7 @@
     "CLSFilename": "/path_to/ground_truth-CLS.tif",
     "NDXFilename": "/path_to/ground_truth-NDX.tif",
     "MTLFilename": "/path_to/ground_truth--MTL.tif",
-    "CLSMatchValue": 6,
+    "CLSMatchValue": [6,65]
   },
   "INPUT.TEST": {
     "DSMFilename": "/path_to/test_model-DSM.tif",

--- a/geometrics/threshold_geometry_metrics.py
+++ b/geometrics/threshold_geometry_metrics.py
@@ -16,14 +16,12 @@ def calcMops(true_positives, false_negatives, false_positives):
     return s
 
 
-def run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
+def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, testMask,
                                    tform, ignoreMask):
-    refMask = (refMask == REF_CLS_VALUE)
     refHgt = (refDSM - refDTM)
     refObj = refHgt
     refObj[~refMask] = 0
 
-    testMask = (testMask == TEST_CLS_VALUE)
     testHgt = (testDSM - testDTM)
     testObj = np.copy(testHgt)
     testObj[~testMask] = 0

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -93,12 +93,12 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
         config = {s:dict(parser.items(s)) for s in parser.sections()}   
 
         # special section/item parsing
-        s = 'INPUT.TEST'; i = 'CLSMatchValue'; config[s][i] = int(config[s][i])
-        s = 'INPUT.REF'; i = 'CLSMatchValue'; config[s][i] = int(config[s][i])
+        s = 'INPUT.TEST'; i = 'CLSMatchValue'; config[s][i] = [int(v) for v in config[s][i].split(',')]
+        s = 'INPUT.REF'; i = 'CLSMatchValue'; config[s][i] = [int(v) for v in config[s][i].split(',')]
         s = 'OPTIONS'; i = 'QuantizeHeight'; config[s][i] = bool(config[s][i])
         s = 'PLOTS'; i = 'DoPlots'; config[s][i] = bool(config[s][i])
         s = 'MATERIALS.REF'; i = 'MaterialNames'; config[s][i] = config[s][i].split(',')
-        s = 'MATERIALS.REF'; i = 'MaterialIndicesToIgnore'; config[s][i] = list(map(int, config[s][i].split(',')))
+        s = 'MATERIALS.REF'; i = 'MaterialIndicesToIgnore'; config[s][i] = [int(v) for v in config[s][i].split(',')]
 
     # unrecognized config file type
     else:

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -112,6 +112,16 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
         print('\n=====PROCESSING FILES FOR "{}"====='.format(sec))
         config[sec] = findfiles(config[sec],path)
 
+    # check for iterable configuration options (e.g., list or tuple)
+    opts = (('INPUT.TEST','CLSMatchValue'),('INPUT.REF','CLSMatchValue'),
+        ('MATERIALS.REF','MaterialIndicesToIgnore'))
+
+    for opt in opts:
+        s = opt[0]; i = opt[1];
+        try:
+            _ = (v for v in config[s][i])
+        except:
+            config[s][i] = [config[s][i]]
 
     # print final configuration
     print('\n=====FINAL CONFIGURATION=====')
@@ -123,7 +133,6 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
     testDTMFilename = config['INPUT.TEST']['DTMFilename']
     testCLSFilename = config['INPUT.TEST']['CLSFilename']
     testMTLFilename = config['INPUT.TEST']['MTLFilename']
-    TEST_CLS_VALUE = config['INPUT.TEST']['CLSMatchValue']
 
     # Get reference model information from configuration file.
     refDSMFilename = config['INPUT.REF']['DSMFilename']
@@ -131,7 +140,6 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
     refCLSFilename = config['INPUT.REF']['CLSFilename']
     refNDXFilename = config['INPUT.REF']['NDXFilename']
     refMTLFilename = config['INPUT.REF']['MTLFilename']
-    REF_CLS_VALUE = config['INPUT.REF']['CLSMatchValue']
 
     # Get material label names and list of material labels to ignore in evaluation.
     materialNames = config['MATERIALS.REF']['MaterialNames']
@@ -157,7 +165,7 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
     # Read reference model files.
     print("")
     print("Reading reference model files...")
-    refMask, tform = geo.imageLoad(refCLSFilename)
+    refCLS, tform = geo.imageLoad(refCLSFilename)
     refDSM = geo.imageWarp(refDSMFilename, refCLSFilename)
     refDTM = geo.imageWarp(refDTMFilename, refCLSFilename)
     refNDX = geo.imageWarp(refNDXFilename, refCLSFilename, interp_method=gdalconst.GRA_NearestNeighbour).astype(np.uint16)
@@ -167,25 +175,34 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
     print("Reading test model files...")
     print("")
     testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
-    testMask = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour)
+    testCLS = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour)
     testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset)
     testMTL = geo.imageWarp(testMTLFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour).astype(np.uint8)
 
     testDSM = testDSM + xyzOffset[2]
     testDTM = testDTM + xyzOffset[2]
 
+    # object masks based on CLSMatchValue(s)
+    refMask = np.zeros_like(refCLS, np.bool)
+    for v in config['INPUT.REF']['CLSMatchValue']:
+        refMask[refCLS == v] = True
+
+    testMask = np.zeros_like(testCLS, np.bool)
+    for v in config['INPUT.TEST']['CLSMatchValue']:
+        testMask[testCLS == v] = True    
+
     # Create mask for ignoring points labeled NoData in reference files.
     refDSM_NoDataValue = geo.getNoDataValue(refDSMFilename)
     refDTM_NoDataValue = geo.getNoDataValue(refDTMFilename)
     refCLS_NoDataValue = geo.getNoDataValue(refCLSFilename)
-    ignoreMask = np.zeros_like(refMask, np.bool)
+    ignoreMask = np.zeros_like(refCLS, np.bool)
 
     if refDSM_NoDataValue is not None:
         ignoreMask[refDSM == refDSM_NoDataValue] = True
     if refDTM_NoDataValue is not None:
         ignoreMask[refDTM == refDTM_NoDataValue] = True
     if refCLS_NoDataValue is not None:
-        ignoreMask[refMask == refCLS_NoDataValue] = True
+        ignoreMask[refCLS == refCLS_NoDataValue] = True
 
     # If quantizing to voxels, then match vertical spacing to horizontal spacing.
     QUANTIZE = config['OPTIONS']['QuantizeHeight']
@@ -197,7 +214,7 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
         testDTM = np.round(testDTM / unitHgt) * unitHgt
 
     # Run the threshold geometry metrics and report results.
-    metrics = geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, REF_CLS_VALUE, testDSM, testDTM, testMask, TEST_CLS_VALUE,
+    metrics = geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, testMask,
                                        tform, ignoreMask)
 
     metrics['offset'] = xyzOffset


### PR DESCRIPTION
Allow both CLSMatchValue integer or list.

Example use case - four large buildings are present in CORE3D site D1 in both reference and test DSMs.  Reference buildings are marked in with CLS values of 6 and 65, thus both CLSMatchValues must be considered for accurate metrics.