### PR TITLE
ALIGN3D update (now on $PATH)

### DIFF
--- a/geometrics/registration.py
+++ b/geometrics/registration.py
@@ -10,13 +10,14 @@ import gdal
 
 def align3d(reference_filename, test_filename, exec_path=None):
 
-    # default location of the align3d executable.
-    if exec_path is None: exec_path = os.path.dirname(os.path.realpath(__file__))
+    # align3d executable (typically on the system $PATH)
+    exec_filename = 'align3d'
 
     # locate align3d executable
-    exec_filename = os.path.abspath(os.path.join(exec_path,'align3d'))
-    if not os.path.isfile(exec_filename):
-        raise IOError('"align3d" executable not found at <{}>'.format(exec_filename))
+    if exec_path: 
+        exec_filename = os.path.abspath(os.path.join(exec_path,exec_filename))
+        if not os.path.isfile(exec_filename):
+            raise IOError('"align3d" executable not found at <{}>'.format(exec_filename))
 
     # In case file names have relative paths, convert to absolute paths.
     reference_filename = os.path.abspath(reference_filename)

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -159,9 +159,9 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
 
     # Register test model to ground truth reference model.
     print('\n=====REGISTRATION====='); sys.stdout.flush()
-    if 'REGEXEPATH' in config:
+    try:
         align3d_path = config['REGEXEPATH']['Align3DPath']
-    else:
+    except:
         align3d_path = None
     xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy, exec_path=align3d_path)
 

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -159,7 +159,10 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None):
 
     # Register test model to ground truth reference model.
     print('\n=====REGISTRATION====='); sys.stdout.flush()
-    align3d_path = config['REGEXEPATH']['Align3DPath']
+    if 'REGEXEPATH' in config:
+        align3d_path = config['REGEXEPATH']['Align3DPath']
+    else:
+        align3d_path = None
     xyzOffset = geo.align3d(refDSMFilename, testDSMFilename_copy, exec_path=align3d_path)
 
     # Read reference model files.


### PR DESCRIPTION
As per [this pubgeo/pubgeo commit](https://github.com/pubgeo/pubgeo/commit/9a2367cb5c94cd39f251fdd80689a53284145fb2), ALIGN3D is now on the regular $PATH of the docker image.  

* Change `registration.py` default to assume ALIGN3D is available on path
* Change `run_geometrics.py` to make REGEXEPATH optional