### PR TITLE
Optional test DTM

### DIFF
--- a/geometrics/config_schema.json
+++ b/geometrics/config_schema.json
@@ -61,7 +61,6 @@
          "type": "object",
          "required": [
             "DSMFilename",
-            "DTMFilename",
             "CLSFilename",
             "CLSMatchValue"
          ],
@@ -71,7 +70,14 @@
                "type": "string"
             },
             "DTMFilename": {
-               "type": "string"
+               "oneOf": [
+                  {
+                     "type": "string"
+                  }, 
+                  {
+                     "type": "null"
+                  }
+               ]
             },
             "CLSFilename": {
                "type": "string"

--- a/run_geometrics.py
+++ b/run_geometrics.py
@@ -31,7 +31,7 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,align=T
 
     # Get test model information from configuration file.
     testDSMFilename = config['INPUT.TEST']['DSMFilename']
-    testDTMFilename = config['INPUT.TEST']['DTMFilename']
+    testDTMFilename = config['INPUT.TEST'].get('DTMFilename',None)
     testCLSFilename = config['INPUT.TEST']['CLSFilename']
     testMTLFilename = config['INPUT.TEST'].get('MTLFilename',None)
 
@@ -82,15 +82,19 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,align=T
     # Read test model files and apply XYZ offsets.
     print("Reading test model files...")
     print("")
-    testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
     testCLS = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour)
     testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset)
+    testDSM = testDSM + xyzOffset[2]
+
+    if testDTMFilename:
+        testDTM = geo.imageWarp(testDTMFilename, refCLSFilename, xyzOffset)
+        testDTM = testDTM + xyzOffset[2]
+    else:
+        print('NO TEST DTM: defaults to reference DTM')
+        testDTM = refDTM
 
     if testMTLFilename:
         testMTL = geo.imageWarp(testMTLFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour).astype(np.uint8)
-
-    testDSM = testDSM + xyzOffset[2]
-    testDTM = testDTM + xyzOffset[2]
 
     # object masks based on CLSMatchValue(s)
     refMask = np.zeros_like(refCLS, np.bool)


### PR DESCRIPTION
Make test DTM optional, defaulting to the reference DTM if no test DTM is provided.   This allows test models to be evaluated without being impacted by differences in terrain.