### PR TITLE
Develop mode for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,13 @@ RUN apt update && apt upgrade -y && apt install -y --fix-missing --no-install-re
 RUN apt autoremove -y && rm -rf /var/lib/apt/lists/*
 RUN pip3 install matplotlib laspy setuptools "jsonschema==2.6.0" "numpy>=1.13"
 WORKDIR /
-RUN git clone https://github.com/pubgeo/GeoMetrics && cd GeoMetrics && git checkout docker_installation_test && python3 setup.py install
+
+ARG DOCKER_DEPLOY=true
+ENV DOCKER_DEPLOY=$DOCKER_DEPLOY
+RUN if [ "$DOCKER_DEPLOY" = true ] ; then \
+        pip3 install --no-deps git+https://github.com/drewgilliam/core3d-metrics@68da71899cdfd0576cc1368c428c12f2c4c53673; \
+    fi
+
 RUN apt purge -y \
     git
 CMD echo "Please run GeoMetrics with an AOI configuration"\

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,15 @@ WORKDIR /
 ARG DOCKER_DEPLOY=true
 ENV DOCKER_DEPLOY=$DOCKER_DEPLOY
 RUN if [ "$DOCKER_DEPLOY" = true ] ; then \
-        pip3 install --no-deps git+https://github.com/drewgilliam/core3d-metrics@68da71899cdfd0576cc1368c428c12f2c4c53673; \
+        pip3 install --no-deps git+https://github.com/pubgeo/core3d-metrics; \
     fi
 
 RUN apt purge -y \
     git
+
+ADD entrypoint.bsh /
+RUN chmod 755 /entrypoint.bsh
+ENTRYPOINT ["/entrypoint.bsh"]
+
 CMD echo "Please run GeoMetrics with an AOI configuration"\
     echo "docker run --rm -v /home/ubuntu/annoteGeoExamples:/data jhuapl/geometrics python3 -m core3dmetrics -c <aoi config>"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include core3dmetrics/geometrics/config_schema.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,5 @@ services:
         - DOCKER_DEPLOY=false
     image: jhuapl/geometrics-develop
     volumes:
-      - ./temp:/src/temp
       - .:/src:ro
     working_dir: /src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
     image: jhuapl/geometrics
 
-  geometrics-develop:
+  geometrics_develop:
     extends:
       service: geometrics
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,21 @@
 version: "2.3"
 
 services:
+
   geometrics:
     build:
       context: .
       dockerfile: Dockerfile
     image: jhuapl/geometrics
+
+  geometrics-develop:
+    extends:
+      service: geometrics
+    build:
+      args:
+        - DOCKER_DEPLOY=false
+    image: jhuapl/geometrics-develop
     volumes:
+      - ./temp:/src/temp
       - .:/src:ro
+    working_dir: /src

--- a/entrypoint.bsh
+++ b/entrypoint.bsh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# install current module in develop mode
+if [ "$DOCKER_DEPLOY" = false ] ; then
+  echo "ENTERING DEVELOP MODE"
+  echo "Installing local core3dmetrics code via 'pip install -e'" 
+
+  # copy source directory contents to shadow directory
+  mkdir -p /src-shadow
+  ln -s /src/* /src-shadow
+
+  # install from shadow directory
+  # this avoids a "*.egg-info" directory being created in the source directory
+  pip3 install --no-deps -e /src-shadow
+
+  echo "\n\n"
+fi
+
+# run incoming command
+if [ "${@+$1}" == "some_app_name" ]; then
+  echo "some_app_name"
+else
+  exec "${@}"
+fi
+

--- a/entrypoint.bsh
+++ b/entrypoint.bsh
@@ -7,15 +7,13 @@ if [ "$DOCKER_DEPLOY" = false ] ; then
   echo "ENTERING DEVELOP MODE"
   echo "Installing local core3dmetrics code via 'pip install -e'" 
 
-  # copy source directory contents to shadow directory
+  # install from linked shadow directory
+  # this avoids a "*.egg-info" directory being created in the source directory
   mkdir -p /src-shadow
   ln -s /src/* /src-shadow
-
-  # install from shadow directory
-  # this avoids a "*.egg-info" directory being created in the source directory
   pip3 install --no-deps -e /src-shadow
 
-  echo "\n\n"
+  printf "\n\n"
 fi
 
 # run incoming command

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     author='JHU/APL',
     author_email='john.doe@jhuapl.edu',
     packages=find_packages(exclude=['aoi-example']),
-    data_files=[('core3dmetrics/geometrics', ['core3dmetrics/geometrics/config_schema.json'])],
+    # data_files=[('core3dmetrics/geometrics', ['core3dmetrics/geometrics/config_schema.json'])],
+    include_package_data=True,
     install_requires=['gdal', 'laspy', 'matplotlib', 'numpy', 'scipy'],
     entry_points = {'console_scripts': ['core3d-metrics=core3dmetrics:main']},
     ## entry_points={  # Optional

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     author='JHU/APL',
     author_email='john.doe@jhuapl.edu',
     packages=find_packages(exclude=['aoi-example']),
-    # data_files=[('core3dmetrics/geometrics', ['core3dmetrics/geometrics/config_schema.json'])],
     include_package_data=True,
     install_requires=['gdal', 'laspy', 'matplotlib', 'numpy', 'scipy'],
     entry_points = {'console_scripts': ['core3d-metrics=core3dmetrics:main']},


### PR DESCRIPTION
PR #16 installs the current master branch into the Docker, making it difficult to use local source code within the docker during development.  This update adds a development docker  based on the deployment docker, favoring local source code over the master branch.

Changes include:
* Dockerfile with optional installation of core3dmetrics module based on build argument (defaults to install=true).  
* pip install instead of "python setup.py ..."
* Dockerfile entrypoint to manage pip install of local module during development
* docker-compose for both deployment and development dockers
* new method for config_schema.json install (MANIFEST.in)

Note running in docker will fail until after merge, as the Dockerfile installs from the master branch which does not currently include the MANIFEST.in update. 

Temporarily switch the docker line:
`pip3 install --no-deps git+https://github.com/pubgeo/core3d-metrics;`
to 
`pip3 install --no-deps git+https://github.com/drewgilliam/core3d-metrics@docker_develop;`
to test.
