### PR TITLE
Fix permissions on output files

### DIFF
--- a/core3dmetrics/geometrics/registration.py
+++ b/core3dmetrics/geometrics/registration.py
@@ -3,7 +3,6 @@
 #
 
 import os
-import stat
 import platform
 import numpy as np
 import gdal
@@ -65,4 +64,4 @@ def getXYZoffsetFilename(testFilename):
 
 
 def unroot(filename):
-    os.chmod(filename, stat.S_IRGRP | stat.S_IWGRP)
+    os.chmod(filename, 0o644)


### PR DESCRIPTION
Ensure output files have standard permissions of user read/write, group read, and other read. Previously, the permissions were set exclusively to group read/write. When running outside of the Docker container--and not as root--this caused errors reading the output files.