### PR TITLE
Clipped plots

### DIFF
--- a/core3dmetrics/geometrics/plot.py
+++ b/core3dmetrics/geometrics/plot.py
@@ -70,7 +70,13 @@ class plot:
         if image is None:
             return plt
 
-        hImg = plt.imshow(image)
+        imshow_kwargs = {}
+        keys = ['vmin','vmax']
+        for key in keys:
+            if key in kwargs:
+                imshow_kwargs[key] = kwargs[key]
+
+        hImg = plt.imshow(image,**imshow_kwargs)
         mpl.cm.get_cmap().set_bad(color=self.badColor)
 
         if 'cmap' in kwargs:

--- a/core3dmetrics/geometrics/relative_accuracy_metrics.py
+++ b/core3dmetrics/geometrics/relative_accuracy_metrics.py
@@ -23,9 +23,8 @@ def run_relative_accuracy_metrics(refDSM, testDSM, refMask, testMask, ignoreMask
         errorMap = delta
         delta[refMask == 0] = np.nan
         plot.make(errorMap, 'Object Height Error', 581, saveName="relVertAcc_hgtErr", colorbar=True)
-        errorMap[errorMap > 5] = 5
-        errorMap[errorMap < -5] = -5
-        plot.make(errorMap, 'Object Height Error (Clipped)', 582, saveName="relVertAcc_hgtErr_clipped", colorbar=True)
+        plot.make(errorMap, 'Object Height Error (Clipped)', 582, saveName="relVertAcc_hgtErr_clipped", colorbar=True,
+            vmin=-5,vmax=5)
 
     # Compute relative horizontal accuracy
     # Consider only objects selected in reference mask.

--- a/core3dmetrics/geometrics/threshold_geometry_metrics.py
+++ b/core3dmetrics/geometrics/threshold_geometry_metrics.py
@@ -106,10 +106,8 @@ def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, te
         errorMap[overlapMask == 1]  =  overlap[overlapMask == 1]
 
         plot.make(errorMap, 'Height Error', 291, saveName=PLOTS_SAVE_PREFIX+"errHgt", colorbar=True)
-
-        errorMap[errorMap > 5] = 5
-        errorMap[errorMap < -5] = -5
-        plot.make(errorMap, 'Height Error', 292, saveName=PLOTS_SAVE_PREFIX+"errHgtClipped", colorbar=True)
+        plot.make(errorMap, 'Height Error (clipped)', 292, saveName=PLOTS_SAVE_PREFIX+"errHgtClipped", colorbar=True,
+            vmin=-5,vmax=5)
 
         tmp = deltaTop
         tmp[ignoreMask] = np.nan


### PR DESCRIPTION
Avoid warnings during plot (e.g., "RuntimeWarning: invalid value encountered in greater") by using vmin/vmax in imshow for clipped plots.