### PR TITLE
Valid metrics

### DIFF
--- a/core3dmetrics/run_geometrics.py
+++ b/core3dmetrics/run_geometrics.py
@@ -191,15 +191,22 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,align=T
     metrics['threshold_geometry'] = geo.run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, refDTM, testMask,
                                        tform, ignoreMask, plot=plot)
 
-    metrics['registration_offset'] = xyzOffset
+    if align:
+        metrics['registration_offset'] = xyzOffset
+
     # Run the terrain model metrics and report results.
-    dtm_z_threshold = config['OPTIONS'].get('TerrainZErrorThreshold',1)
-    metrics['terrain_accuracy'] = geo.run_terrain_accuracy_metrics(refDSM, refDTM, testDSM, testDTM, refMask, testMask, dtm_z_threshold, geo.getUnitArea(tform), plot=plot)
+    if testDTMFilename:
+        dtm_z_threshold = config['OPTIONS'].get('TerrainZErrorThreshold',1)
+        metrics['terrain_accuracy'] = geo.run_terrain_accuracy_metrics(refDSM, refDTM, testDSM, testDTM, refMask, testMask, dtm_z_threshold, geo.getUnitArea(tform), plot=plot)
+    else:
+        print('WARNING: No test DTM file, skipping terrain accuracy metrics')
+
+    # Run the relative accuracy metrics and report results. 
     metrics['relative_accuracy'] = geo.run_relative_accuracy_metrics(refDSM, testDSM, refMask, testMask, ignoreMask, geo.getUnitWidth(tform), plot=plot)
 
     # Run the threshold material metrics and report results.
     if testMTLFilename:
-            metrics['threshold_materials'] = geo.run_material_metrics(refNDX, refMTL, testMTL, materialNames, materialIndicesToIgnore)
+        metrics['threshold_materials'] = geo.run_material_metrics(refNDX, refMTL, testMTL, materialNames, materialIndicesToIgnore)
     else:
         print('WARNING: No test MTL file, skipping material metrics')
 


### PR DESCRIPTION
Only report metrics for valid input options.
* Report registration offset only if alignment was run
* Report terrain accuracy metrics only for valid test DTM

This ensures the metrics output does not give a false sense of accuracy (for example, listing perfect terrain accuracy when the reference DTM was used as test DTM).