### PR TITLE
Image reprojection

### DIFF
--- a/core3dmetrics/geometrics/image.py
+++ b/core3dmetrics/geometrics/image.py
@@ -1,5 +1,7 @@
+import os
 import gdal
 import numpy as np
+
 
 def imageLoad(filename):
     im = gdal.Open(filename, gdal.GA_ReadOnly)
@@ -16,7 +18,44 @@ def getNoDataValue(filename):
     return nodata
 
 
+def getMetadata(inputinfo):
+
+    # dataset input
+    if isinstance(inputinfo,gdal.Dataset):
+        dataset = inputinfo
+        FLAG_CLOSE = False
+
+    # file input
+    elif isinstance(inputinfo,str):
+        filename = inputinfo
+        if not os.path.isfile(filename):
+            raise IOError('Cannot locate file <{}>'.format(filename))
+
+        dataset = gdal.Open(filename, gdal.GA_ReadOnly)
+        FLAG_CLOSE = True
+
+    # unrecognized input
+    else:
+        raise IOError('Unrecognized getMetadata input')
+
+    # read metadata
+    meta = {
+        'RasterXSize':  dataset.RasterXSize,
+        'RasterYSize':  dataset.RasterYSize,
+        'RasterCount':  dataset.RasterCount,
+        'Projection':   dataset.GetProjection(),
+        'GeoTransform': list(dataset.GetGeoTransform()),
+    }
+
+    # cleanuo
+    if FLAG_CLOSE: dataset = None
+    return meta
+
+
 def imageWarp(file_src: str, file_dst: str, offset=None, interp_method: int = gdal.gdalconst.GRA_Bilinear, noDataValue=None):
+
+    # verbose display
+    print('Loading <{}>'.format(file_src))
 
     # GDAL memory driver
     mem_drv = gdal.GetDriverByName('MEM')
@@ -24,14 +63,6 @@ def imageWarp(file_src: str, file_dst: str, offset=None, interp_method: int = gd
     # copy source to memory
     tmp = gdal.Open(file_src, gdal.GA_ReadOnly)
     dataset_src = mem_drv.CreateCopy('',tmp)   
-    tmp = None
-
-    # destination metadata
-    tmp = gdal.Open(file_dst, gdal.GA_ReadOnly)
-    xsz = tmp.RasterXSize
-    ysz = tmp.RasterYSize
-    prj = tmp.GetProjection()
-    geo = tmp.GetGeoTransform()  
     tmp = None
 
     # change no data value to new "noDataValue" input if necessary,
@@ -47,26 +78,44 @@ def imageWarp(file_src: str, file_dst: str, offset=None, interp_method: int = gd
         band.SetNoDataValue(noDataValue)        
         NDV = noDataValue
 
+    # source metadata
+    meta_src = getMetadata(dataset_src)
+
     # Apply registration offset
     if offset is not None:
-        transform = np.array(dataset_src.GetGeoTransform())
+        transform = meta_src['GeoTransform']
         transform[0] += offset[0]
         transform[3] += offset[1]
-        dataset_src.SetGeoTransform(tuple(transform))
+        dataset_src.SetGeoTransform(transform)
 
-    # Create output dataset
-    dataset_dst = mem_drv.Create('',xsz,ysz,1,gdal.GDT_Float32)
-    dataset_dst.SetProjection(prj)
-    dataset_dst.SetGeoTransform(geo)
+    # destination metadata
+    meta_dst = getMetadata(file_dst)
 
-    if NDV is not None:
-        band = dataset_dst.GetRasterBand(1)
-        band.SetNoDataValue(NDV)
-        band.Fill(NDV)
-    
-    # reproject src data to dst coordinate space
-    gdal.ReprojectImage(dataset_src, dataset_dst, dataset_src.GetProjection(),
-                        prj, interp_method)
+    # no reprojection necessary
+    if meta_src == meta_dst:
+        print('  No reprojection')
+        dataset_dst = dataset_src
+
+    # reprojection
+    else:
+        keys = [k for k in meta_dst if meta_dst.get(k) != meta_src.get(k)]
+        print('  REPROJECTION (adjusting {})'.format(', '.join(keys)))
+
+        # file, xsz, ysz, nbands, dtype
+        dataset_dst = mem_drv.Create('', meta_dst['RasterXSize'], meta_dst['RasterYSize'], 
+            meta_src['RasterCount'], gdal.GDT_Float32)
+
+        dataset_dst.SetProjection(meta_dst['Projection'])
+        dataset_dst.SetGeoTransform(meta_dst['GeoTransform'])
+
+        if NDV is not None:
+            band = dataset_dst.GetRasterBand(1)
+            band.SetNoDataValue(NDV)
+            band.Fill(NDV)
+
+        # input, output, inputproj, outputproj, interp
+        gdal.ReprojectImage(dataset_src, dataset_dst, meta_src['Projection'],
+             meta_dst['Projection'], interp_method)
 
     # read & return image data
     img = dataset_dst.GetRasterBand(1).ReadAsArray()    

--- a/core3dmetrics/geometrics/image.py
+++ b/core3dmetrics/geometrics/image.py
@@ -57,6 +57,9 @@ def imageWarp(file_src: str, file_dst: str, offset=None, interp_method: int = gd
     # verbose display
     print('Loading <{}>'.format(file_src))
 
+    # destination metadata
+    meta_dst = getMetadata(file_dst)
+
     # GDAL memory driver
     mem_drv = gdal.GetDriverByName('MEM')
 
@@ -83,13 +86,19 @@ def imageWarp(file_src: str, file_dst: str, offset=None, interp_method: int = gd
 
     # Apply registration offset
     if offset is not None:
+
+        # offset error: offset is defined in destination projection space,
+        # and cannot be applied if source and destination projections differ
+        if meta_src['Projection'] != meta_dst['Projection']:
+            print('IMAGE PROJECTION\n{}'.format(meta_src['Projection']))
+            print('OFFSET PROJECTION\n{}'.format(meta_dst['Projection']))
+            raise ValueError('Image/Offset projection mismatch')
+
         transform = meta_src['GeoTransform']
         transform[0] += offset[0]
         transform[3] += offset[1]
         dataset_src.SetGeoTransform(transform)
 
-    # destination metadata
-    meta_dst = getMetadata(file_dst)
 
     # no reprojection necessary
     if meta_src == meta_dst:

--- a/core3dmetrics/run_geometrics.py
+++ b/core3dmetrics/run_geometrics.py
@@ -90,10 +90,9 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,
 
     # Explicitly assign a no data value to warped images to track filled pixels
     noDataValue = -9999
-    
+
     # Read reference model files.
-    print("")
-    print("Reading reference model files...")
+    print("\nReading reference model files...")
     refCLS, tform = geo.imageLoad(refCLSFilename)
     refDSM = geo.imageWarp(refDSMFilename, refCLSFilename, noDataValue=noDataValue)
     refDTM = geo.imageWarp(refDTMFilename, refCLSFilename, noDataValue=noDataValue)
@@ -101,10 +100,11 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,
 
     if refMTLFilename:
         refMTL = geo.imageWarp(refMTLFilename, refCLSFilename, interp_method=gdalconst.GRA_NearestNeighbour).astype(np.uint8)
+    else:
+        print('NO REFERENCE MTL')
 
     # Read test model files and apply XYZ offsets.
-    print("Reading test model files...")
-    print("")
+    print("\nReading test model files...")
     testCLS = geo.imageWarp(testCLSFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour)
     testDSM = geo.imageWarp(testDSMFilename, refCLSFilename, xyzOffset, noDataValue=noDataValue)
 
@@ -116,6 +116,10 @@ def run_geometrics(configfile,refpath=None,testpath=None,outputpath=None,
 
     if testMTLFilename:
         testMTL = geo.imageWarp(testMTLFilename, refCLSFilename, xyzOffset, gdalconst.GRA_NearestNeighbour).astype(np.uint8)
+    else:
+        print('NO TEST MTL')
+
+    print("\n\n")
 
     # Apply registration offset, only to valid data to allow better tracking of bad data
     testValidData = (testDSM != noDataValue) & (testDSM != noDataValue)


### PR DESCRIPTION
* Reproject image only when necessary
* Warn if reprojection is not possible (fixes #31) - for example, test imagery is in WGS84 projection, but offset is in UTM projection and cannot be applied to test imagery
* various printout adjustments