### PR TITLE
Unit tests & Geometry Refactor

### DIFF
--- a/core3dmetrics/geometrics/metrics_util.py
+++ b/core3dmetrics/geometrics/metrics_util.py
@@ -27,6 +27,11 @@ def calcMops(true_positives, false_negatives, false_positives):
         s['correctness'] = s['precision']
         s['fscore'] = (2 * s['recall'] * s['precision']) / (s['recall'] + s['precision'])
 
+    # append actual TP/FN/FP to report
+    s['TP'] = float(true_positives)
+    s['FN'] = float(false_negatives)
+    s['FP'] = float(false_positives)
+
     return s
 
 

--- a/core3dmetrics/geometrics/metrics_util.py
+++ b/core3dmetrics/geometrics/metrics_util.py
@@ -2,17 +2,17 @@ import numpy as np
 
 def calcMops(true_positives, false_negatives, false_positives):
 
-
-    if (true_positives == 0) and (false_positives == 0):
+    # when user gets nothing correct
+    if (true_positives == 0):
         s = {
             'recall': 0,
-            'precision': np.nan,
+            'precision': 0,
             'jaccardIndex': 0,
             'branchingFactor': np.nan,
-            'missFactor': np.inf,
+            'missFactor': np.nan,
             'completeness': 0,
-            'correctness': np.nan,
-           'fscore': np.nan
+            'correctness': 0,
+            'fscore': np.nan
         }
 
     else:

--- a/core3dmetrics/geometrics/threshold_geometry_metrics.py
+++ b/core3dmetrics/geometrics/threshold_geometry_metrics.py
@@ -17,7 +17,7 @@ def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, te
         PLOTS_ENABLE = False
     else:
         PLOTS_ENABLE = True
-        PLOTS_SAVE_PREFIX = "thresholdGeometry_"    
+        PLOTS_SAVE_PREFIX = "thresholdGeometry_"
                                    
     # Determine evaluation units.
     unitArea = getUnitArea(tform)
@@ -55,7 +55,7 @@ def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, te
         plot.make(ref_footprint, 'Reference Object Regions', 211, saveName=PLOTS_SAVE_PREFIX+"refObjMask")
         plot.make(ref_height, 'Reference Object Height', 212, saveName=PLOTS_SAVE_PREFIX+"refObjHgt", colorbar=True)
         
-        plot.make(test_footprint, 'Test Object Regions', 251, saveName=PLOTS_SAVE_PREFIX+"testObjHgt")
+        plot.make(test_footprint, 'Test Object Regions', 251, saveName=PLOTS_SAVE_PREFIX+"testObjMask")
         plot.make(test_height, 'Test Object Height', 252, saveName=PLOTS_SAVE_PREFIX+"testObjHgt", colorbar=True)
 
         errorMap = (test_height-ref_height)

--- a/core3dmetrics/geometrics/threshold_geometry_metrics.py
+++ b/core3dmetrics/geometrics/threshold_geometry_metrics.py
@@ -38,7 +38,7 @@ def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, te
     ref_total_area = np.sum(ref_footprint,dtype=np.uint64)
     test_total_area = np.sum(test_footprint,dtype=np.uint64)
 
-    # total 3D volume (in meters^2)
+    # total 3D volume (in meters^3)
     ref_total_volume = np.sum(np.absolute(ref_height)) * unitArea
     test_total_volume = np.sum(np.absolute(test_height)) * unitArea
 

--- a/core3dmetrics/geometrics/threshold_geometry_metrics.py
+++ b/core3dmetrics/geometrics/threshold_geometry_metrics.py
@@ -1,121 +1,158 @@
 import numpy as np
 import os
+import json
 
 from .metrics_util import calcMops
 from .metrics_util import getUnitArea
 
 
 def run_threshold_geometry_metrics(refDSM, refDTM, refMask, testDSM, testDTM, testMask,
-                                   tform, ignoreMask, plot=None):
-                     
+                                   tform, ignoreMask, plot=None, verbose=True):
+                    
 
+    # INPUT PARSING==========
+
+    # parse plot input
     if plot is None:
         PLOTS_ENABLE = False
     else:
         PLOTS_ENABLE = True
-        PLOTS_SAVE_PREFIX = "thresholdGeometry_"
+        PLOTS_SAVE_PREFIX = "thresholdGeometry_"    
                                    
-    refHgt = (refDSM - refDTM)
-    refObj = refHgt
-    refObj[~refMask] = 0
-
-    testHgt = (testDSM - testDTM)
-    testObj = np.copy(testHgt)
-    testObj[~testMask] = 0
-
-    # Make metrics
-    refOnlyMask = refMask & ~testMask
-    testOnlyMask = testMask & ~refMask
-    overlapMask = refMask & testMask
-
-    # Apply ignore mask
-    refOnlyMask = refOnlyMask & ~ignoreMask
-    testOnlyMask = testOnlyMask & ~ignoreMask
-    overlapMask = overlapMask & ~ignoreMask
-
-    
-    if PLOTS_ENABLE:
-        plot.make(refMask, 'Reference Object Regions', 211, saveName=PLOTS_SAVE_PREFIX+"refObjMask")
-        plot.make(refObj,  'Reference Object Height', 212, saveName=PLOTS_SAVE_PREFIX+"refObjHgt", colorbar=True)
-        
-        plot.make(testMask, 'Test Object Regions', 251, saveName=PLOTS_SAVE_PREFIX+"testObjHgt")
-        plot.make(testObj, 'Test Object  Height', 252, saveName=PLOTS_SAVE_PREFIX+"testObjHgt", colorbar=True)
-    
-        plot.make(refOnlyMask,  'False Negative Regions', 281, saveName=PLOTS_SAVE_PREFIX+"falseNegetive")
-        plot.make(testOnlyMask, 'False Positive Regions', 282, saveName=PLOTS_SAVE_PREFIX+"falsePositive")
-        plot.make(overlapMask,  'True Positive Regions',  283, saveName=PLOTS_SAVE_PREFIX+"truePositive")
-    
-    
-    
     # Determine evaluation units.
     unitArea = getUnitArea(tform)
+                                 
+    # 2D footprints for evaluation
+    ref_footprint = refMask & ~ignoreMask
+    test_footprint = testMask & ~ignoreMask
 
-    # --- Hard Error ------------------------------------------------------
-    # Regions that are 2D False Positives or False Negatives, are
-    # all or nothing.  These regions don't consider overlap in the
-    # underlying terrain models
+    # building height (DSM-DTM, with zero elevation outside footprint)
+    ref_height = refDSM.astype(np.float64) - refDTM.astype(np.float64)
+    ref_height[~ref_footprint] = 0
 
-    # -------- False Positive ---------------------------------------------
-    unitCountFP = np.sum(testOnlyMask)
-    oobFP = np.sum(testOnlyMask * testObj) * unitArea
+    test_height = testDSM.astype(np.float64) - testDTM.astype(np.float64)
+    test_height[~test_footprint] = 0
 
-    # -------- False Negative ---------------------------------------------
-    unitCountFN = np.sum(refOnlyMask)
-    oobFN = np.sum(refOnlyMask * refObj) * unitArea
+    # total 2D area
+    REF_2D = np.sum(ref_footprint)
+    TEST_2D = np.sum(test_footprint)
 
-    # --- Soft Error ------------------------------------------------------
-    # Regions that are 2D True Positive
+    # total 3D volume 
+    REF_3D = np.sum(np.absolute(ref_height)) * unitArea
+    TEST_3D = np.sum(np.absolute(test_height)) * unitArea
 
-    # For both below:
-    #       Positive values are False Positives
-    #       Negative values are False Negatives
-    deltaTop = testDSM - refDSM
-    deltaBot = refDTM - testDTM
+    # verbose reporting
+    if verbose:
+        print('REF height range [mn,mx] = [{},{}]'.format(np.amin(ref_height),np.amax(ref_height)))
+        print('TEST height range [mn,mx] = [{},{}]'.format(np.amin(test_height),np.amax(test_height)))
+        print('REF area (px), volume (m^3) = [{},{}]'.format(REF_2D,REF_3D))
+        print('TEST area (px), volume (m^3) =  [{},{}]'.format(TEST_2D,TEST_3D))
 
-    # Regions that are 2D True Positives
-    unitCountTP = np.sum(overlapMask)
-    overlap = overlapMask * (testObj - refObj)
-    overlap[np.isnan(overlap)] = 0
-
-    # -------- False Positive -------------------------------------------------
-    false_positives = np.nansum((deltaTop > 0) * deltaTop * overlapMask) * unitArea + \
-         np.nansum((deltaBot > 0) * deltaBot * overlapMask) * unitArea
-
-    # -------- False Negative -------------------------------------------------
-    false_negatives = -np.nansum((deltaTop < 0) * deltaTop * overlapMask) * unitArea + \
-         -np.nansum((deltaBot < 0) * deltaBot * overlapMask) * unitArea
-
-    # -------- True Positive ---------------------------------------------------
-    true_positives = np.nansum(refObj * overlapMask) * unitArea - false_negatives
-    tolFP = false_positives + oobFP
-    tolFN = false_negatives + oobFN
-    tolTP = true_positives
-
-    metrics = {
-        '2D': calcMops(unitCountTP, unitCountFN, unitCountFP),
-        '3D': calcMops(tolTP, tolFN, tolFP),
-    }
-
+    # plot 
     if PLOTS_ENABLE:
-        errorMap = np.empty(refOnlyMask.shape)
-        errorMap[:] = np.nan
-        errorMap[testOnlyMask == 1] =  testObj[testOnlyMask == 1]
-        errorMap[refOnlyMask == 1]  = -refObj[refOnlyMask == 1]
+        print('Input plots...')
 
-        overlap = overlapMask * (testDSM - refDSM)
-        errorMap[overlapMask == 1]  =  overlap[overlapMask == 1]
+        plot.make(ref_footprint, 'Reference Object Regions', 211, saveName=PLOTS_SAVE_PREFIX+"refObjMask")
+        plot.make(ref_height, 'Reference Object Height', 212, saveName=PLOTS_SAVE_PREFIX+"refObjHgt", colorbar=True)
+        
+        plot.make(test_footprint, 'Test Object Regions', 251, saveName=PLOTS_SAVE_PREFIX+"testObjHgt")
+        plot.make(test_height, 'Test Object Height', 252, saveName=PLOTS_SAVE_PREFIX+"testObjHgt", colorbar=True)
 
+        errorMap = (test_height-ref_height)
+        errorMap[~ref_footprint & ~test_footprint] = np.nan
         plot.make(errorMap, 'Height Error', 291, saveName=PLOTS_SAVE_PREFIX+"errHgt", colorbar=True)
         plot.make(errorMap, 'Height Error (clipped)', 292, saveName=PLOTS_SAVE_PREFIX+"errHgtClipped", colorbar=True,
             vmin=-5,vmax=5)
 
-        tmp = deltaTop
-        tmp[ignoreMask] = np.nan
-        plot.make(tmp, 'DSM Error', 293, saveName=PLOTS_SAVE_PREFIX+"errHgtDSM", colorbar=True)
 
-        tmp = deltaBot
-        tmp[ignoreMask] = np.nan
-        plot.make(tmp, 'DTM Error', 294, saveName=PLOTS_SAVE_PREFIX+"errHgtDTM", colorbar=True)
+    # 2D ANALYSIS==========
+
+    # 2D metrics
+    tp_2D =  test_footprint &  ref_footprint
+    fn_2D = ~test_footprint &  ref_footprint
+    fp_2D =  test_footprint & ~ref_footprint
+    
+    TP_2D = np.sum(tp_2D)
+    FN_2D = np.sum(fn_2D)
+    FP_2D = np.sum(fp_2D)
+
+    # error check:
+    if (TP_2D + FN_2D) != REF_2D:
+        raise ValueError('2D TP+FN ({}+{}) does not equal ref area ({})'.format(
+            TP_2D, FN_2D, REF_2D))
+    elif (TP_2D + FP_2D) != TEST_2D:
+        raise ValueError('2D TP+FP ({}+{}) does not equal test area ({})'.format(
+            TP_2D, FP_2D, TEST_2D))
+    
+    # verbose reporting
+    if verbose:
+        print('2D TP+FN ({}+{}) equals ref area ({})'.format(
+            TP_2D, FN_2D, REF_2D))
+        print('2D TP+FP ({}+{}) equals test area ({})'.format(
+            TP_2D, FP_2D, TEST_2D))
+
+    # plot
+    if PLOTS_ENABLE:   
+        print('2D analysis plots...')
+        plot.make(tp_2D, 'True Positive Regions',  283, saveName=PLOTS_SAVE_PREFIX+"truePositive")
+        plot.make(fn_2D, 'False Negative Regions', 281, saveName=PLOTS_SAVE_PREFIX+"falseNegetive")
+        plot.make(fp_2D, 'False Positive Regions', 282, saveName=PLOTS_SAVE_PREFIX+"falsePositive")
 
 
+    # 3D ANALYSIS==========
+
+    # Flip underground reference structures
+    # flip all heights where ref_height is less than zero, allowing subsequent calculations
+    # to only consider difference relative to positive/absolute reference structures
+    tf = ref_height < 0
+    ref_height[tf] = -ref_height[tf]
+    test_height[tf] = -test_height[tf]
+
+    # separate test height into above & below ground sets
+    test_above = np.copy(test_height)
+    test_above[test_height<0] = 0
+
+    test_below = np.copy(test_height)
+    test_below[test_height>0] = 0
+    test_below = np.absolute(test_below)
+
+    # 3D metrics
+    tp_3D = np.minimum(ref_height,test_above) # ref/test height overlap
+    fn_3D = (ref_height - tp_3D) # test too short
+    fp_3D = (test_above - tp_3D) + test_below # test too tall OR test below ground
+    
+    TP_3D = np.sum(tp_3D)*unitArea
+    FN_3D = np.sum(fn_3D)*unitArea
+    FP_3D = np.sum(fp_3D)*unitArea
+
+    # error check:
+    if (TP_3D + FN_3D) != REF_3D:
+        raise ValueError('3D TP+FN ({}+{}) does not equal ref volume ({})'.format(
+            TP_3D, FN_3D, REF_3D))
+    elif (TP_3D + FP_3D) != TEST_3D:
+        raise ValueError('3D TP+FP ({}+{}) does not equal test volume ({})'.format(
+            TP_3D, FP_3D, TEST_3D))
+
+    # verbose reporting
+    if verbose:
+        print('3D TP+FN ({}+{}) equals ref volume ({})'.format(
+            TP_3D, FN_3D, REF_3D))
+        print('3D TP+FP ({}+{}) equals test volume ({})'.format(
+            TP_3D, FP_3D, TEST_3D))
+
+
+    # CLEANUP==========
+
+    # final metrics
+    metrics = {
+        '2D': calcMops(TP_2D, FN_2D, FP_2D),
+        '3D': calcMops(TP_3D, FN_3D, FP_3D),
+    }
+
+    # verbose reporting
+    if verbose:
+        print('METRICS REPORT:')
+        print(json.dumps(metrics,indent=2))
+
+    # return metric dictionary
     return metrics

--- a/entrypoint.bsh
+++ b/entrypoint.bsh
@@ -17,8 +17,8 @@ if [ "$DOCKER_DEPLOY" = false ] ; then
 fi
 
 # run incoming command
-if [ "${@+$1}" == "some_app_name" ]; then
-  echo "some_app_name"
+if [ "${@+$1}" == "test" ]; then
+  python3 -m unittest discover -v
 else
   exec "${@}"
 fi

--- a/test/test_geometrics.py
+++ b/test/test_geometrics.py
@@ -1,0 +1,73 @@
+import unittest
+import numpy as np
+
+import core3dmetrics.geometrics as geo
+
+
+class TestGeometryMetrics(unittest.TestCase):
+
+  def setUp(self):
+    pass
+
+  # common test (unittest does not run, as there is no "test" prefix) 
+  def common_test(self,reffac,testfac,metrics_expected):
+
+    # base inputs
+    DSM = np.array([[0,0,0,0],[0,1,1,0],[0,1,1,0],[0,0,0,0]],dtype=np.float32)
+    sh = DSM.shape
+
+    DTM = np.zeros(sh,dtype=np.float32)
+    MSK = (DSM!=0)
+
+    tform = [0,.5,0,0,0,.5]
+    ignore = np.zeros(sh,dtype=np.bool)
+
+    # calculate metrics
+    metrics = geo.run_threshold_geometry_metrics(
+      reffac*DSM, DTM, MSK, testfac*DSM, DTM, MSK, tform, ignore,
+      plot=None,verbose=True)
+
+    # compare subset of metrics
+    for section in metrics_expected:
+      metrics_subset = {k:metrics[section].get(k) for k in metrics_expected[section]}
+      self.assertDictEqual(metrics_subset, metrics_expected[section],
+          '{} metrics are not as expected'.format(section))
+
+
+  # ref/test both above ground
+  def test_both_positive(self):
+    metrics_expected = {
+      "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
+      "3D": {"TP": 1.0, "FN": 0.0, "FP": 0.0},
+    }
+    self.common_test(1.0,1.0,metrics_expected)
+
+  # ref-test both below ground
+  def test_both_negative(self):
+    metrics_expected = {
+      "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
+      "3D": {"TP": 1.0, "FN": 0.0, "FP": 0.0},
+    }
+    self.common_test(-1.0,-1.0,metrics_expected)
+
+  # testDSM below ground
+  def test_negative_testDSM(self):
+    metrics_expected = {
+      "2D": {"TP": 0.0, "FN": 4.0, "FP": 4.0},
+      "3D": {"TP": 0.0, "FN": 1.0, "FP": 1.0},
+    }
+    self.common_test(1.0,-1.0,metrics_expected)
+
+  # refDSM below ground
+  def test_negative_refDSM(self):
+    metrics_expected = {
+      "2D": {"TP": 0.0, "FN": 4.0, "FP": 4.0},
+      "3D": {"TP": 0.0, "FN": 1.0, "FP": 1.0},
+    }
+    self.common_test(-1.0,1.0,metrics_expected)
+
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_geometry_metrics.py
+++ b/test/test_geometry_metrics.py
@@ -9,23 +9,31 @@ class TestGeometryMetrics(unittest.TestCase):
   def setUp(self):
     pass
 
-  # common test (unittest does not run, as there is no "test" prefix) 
-  def common_test(self,reffac,testfac,metrics_expected):
+  # common  test (unittest does not run, as there is no "test" prefix) 
+  def common_test(self,reffac,testfac,testshft,metrics_expected):
 
     # base inputs
-    DSM = np.array([[0,0,0,0],[0,1,1,0],[0,1,1,0],[0,0,0,0]],dtype=np.float32)
+    DSM = np.array([[1,1,0,0],[1,1,0,0],[0,0,0,0],[0,0,0,0]],dtype=np.float32)
     sh = DSM.shape
-
     DTM = np.zeros(sh,dtype=np.float32)
-    MSK = (DSM!=0)
 
     tform = [0,.5,0,0,0,.5]
     ignore = np.zeros(sh,dtype=np.bool)
 
+    # ref DSM & footprint
+    refDSM = reffac*DSM
+    refMSK = (refDSM!=0)
+
+    # test DSM & footprint
+    testDSM = testfac*DSM
+    testDSM = np.roll(testDSM,testshft[0],axis=0)
+    testDSM = np.roll(testDSM,testshft[1],axis=1)
+    testMSK = (testDSM!=0)
+
     # calculate metrics
     metrics = geo.run_threshold_geometry_metrics(
-      reffac*DSM, DTM, MSK, testfac*DSM, DTM, MSK, tform, ignore,
-      plot=None,verbose=True)
+      refDSM, DTM, refMSK, testDSM, DTM, testMSK, tform, ignore,
+      plot=None,verbose=False)
 
     # compare subset of metrics
     for section in metrics_expected:
@@ -40,7 +48,7 @@ class TestGeometryMetrics(unittest.TestCase):
       "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
       "3D": {"TP": 1.0, "FN": 0.0, "FP": 0.0},
     }
-    self.common_test(1.0,1.0,metrics_expected)
+    self.common_test(1.0,1.0,(0,0),metrics_expected)
 
   # ref-test both below ground
   def test_both_negative(self):
@@ -48,26 +56,35 @@ class TestGeometryMetrics(unittest.TestCase):
       "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
       "3D": {"TP": 1.0, "FN": 0.0, "FP": 0.0},
     }
-    self.common_test(-1.0,-1.0,metrics_expected)
+    self.common_test(-1.0,-1.0,(0,0),metrics_expected)
 
   # testDSM below ground
   def test_negative_testDSM(self):
     metrics_expected = {
-      "2D": {"TP": 0.0, "FN": 4.0, "FP": 4.0},
+      "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
       "3D": {"TP": 0.0, "FN": 1.0, "FP": 1.0},
     }
-    self.common_test(1.0,-1.0,metrics_expected)
+    self.common_test(1.0,-1.0,(0,0),metrics_expected)
 
   # refDSM below ground
   def test_negative_refDSM(self):
     metrics_expected = {
-      "2D": {"TP": 0.0, "FN": 4.0, "FP": 4.0},
+      "2D": {"TP": 4.0, "FN": 0.0, "FP": 0.0},
       "3D": {"TP": 0.0, "FN": 1.0, "FP": 1.0},
     }
-    self.common_test(-1.0,1.0,metrics_expected)
+    self.common_test(-1.0,1.0,(0,0),metrics_expected)
+
+  # shift testDSM
+  def test_shift_testDSM(self):
+    metrics_expected = {
+      "2D": {"TP": 1.0, "FN": 3.0, "FP": 3.0},
+      "3D": {"TP": 0.25, "FN": 0.75, "FP": 0.75},
+    }
+    self.common_test(1.0,1.0,(1,1),metrics_expected)
 
 
 
 
 if __name__ == '__main__':
   unittest.main()
+


### PR DESCRIPTION
Add unit tests via python unittest for threshold geometry metrics.  Unit tests require a docker rebuild as the entrypoint has changed.  Unit tests on your current code base can be run through the docker via the command:
`docker-compose run --rm geometrics_develop test`

Refactor threshold_geometry_metrics.  Code now appropriately handles below ground reference and test structures.  Refactored code also includes sanity checks to make sure TP,FN,FP calculations match expected reference & test footprints/volumes.

Update metrics_util, now including direct report of TP, FP, and FN.  Modify special reporting case to only check TP==0 (which always results in some sort of error/warning).