### PR TITLE
CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/repo
+    docker:
+      - image: docker:18.03.0-ce-git
+    steps:
+
+      - checkout
+
+      - setup_remote_docker
+
+      - run:
+          name: Install software
+          command: |
+            apk update
+            apk add py-pip
+            pip install docker-compose
+            docker-compose --version
+            docker ps
+
+      - run:
+          name: Smuggle repo to remote docker
+          command: tar zc --exclude .git . | docker run -i -v /root/repo:/repo -w /repo alpine:3.6 tar zx
+
+      - run: 
+          name: Build all dockers
+          command: docker-compose build
+
+      - run:
+          name: Unit tests
+          command: docker-compose run --rm geometrics_develop test


### PR DESCRIPTION
Setup for continuous integration via circleci (select "start building now" [here](https://circleci.com/integrations/github/))

Once circleci is enabled, this file will run docker build and unit tests.  Initial unit tests are available in pull request #39 (unit test step will fail until PR #39 is accepted).  