### PR TITLE
non-interactive apt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM jhuapl/pubgeo:latest
-RUN apt update && apt upgrade -y && apt install -y --fix-missing --no-install-recommends \
+RUN apt update && apt upgrade -y && \
+  DEBIAN_FRONTEND=noninteractive apt install -y --fix-missing --no-install-recommends \
     git \
 	python3 \
 	python3-pip \


### PR DESCRIPTION
upstream docker updates cause tzdata dependency to request user input during docker build.  Add `DEBIAN_FRONTEND=noninteractive` flag before `apt install` command to ensure docker builds successfully without user interaction.